### PR TITLE
removed manual trigger and run code coverage collection only in pull …

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -5,8 +5,6 @@ on:
     branches: [ develop, master ]
   pull_request:
     branches: [ develop, master ]
-  workflow_dispatch:
-    branches: [ develop, master ]
 
 jobs:
   build:
@@ -33,7 +31,9 @@ jobs:
       with:
         reports: '${{ env.COVERAGE_REPORTS }}'
         reporttypes: 'lcov;HtmlInline'
-    - name: publish code coverage results
+    # known issue in https://github.com/romeovs/lcov-reporter-action/issues/1
+    - if: github.event_name == 'pull_request'
+      name: publish code coverage results
       uses: romeovs/lcov-reporter-action@v0.2.16
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
removed manual trigger and run code coverage collection only in pull request context (see [lcov-reporter-action issue)](https://github.com/romeovs/lcov-reporter-action/issues/1)