### PR TITLE
add FastExpressionCompiler package and update RuleCompiler to use CompileFast

### DIFF
--- a/src/LogicEngine/Compilers/RuleCompiler.cs
+++ b/src/LogicEngine/Compilers/RuleCompiler.cs
@@ -11,6 +11,7 @@ using static System.Globalization.CultureInfo;
 using static System.Linq.Expressions.Expression;
 using static TinyFp.Prelude;
 using Convert = System.Convert;
+using FastExpressionCompiler;
 
 namespace LogicEngine.Compilers;
 
@@ -26,7 +27,7 @@ public class RuleCompiler : IRuleCompiler
         rule
             .Map(CreateCompiledRule<T>)
             .Map(t => (exp: Lambda<Func<T, bool>>(t.Item1, t.Item2), code: t.Item3))
-            .Map(t => (func: t.exp.Compile(), t.code))
+            .Map(t => (func: t.exp.CompileFast(), t.code))
             .Map(t => new CompiledRule<T>(t.func, t.code));
 
     private static Option<(BinaryExpression, ParameterExpression, string)> CreateCompiledRule<T>(Rule rule) =>

--- a/src/LogicEngine/LogicEngine.csproj
+++ b/src/LogicEngine/LogicEngine.csproj
@@ -13,6 +13,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="FastExpressionCompiler" Version="5.3.0" />
     <PackageReference Include="tiny-fp" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Introduced [FastExpressionCompiler](https://github.com/dadhi/FastExpressionCompiler) to compile expressions into functions.
The change is simple and allows for huge performance improvements:

The following test (using BenchmarkDotNet) shows a ~15x performance improvement using `CompileFast` over the standard Expression `Compile`:

```csharp
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using LogicEngine.Compilers;
using LogicEngine.Internals;
using LogicEngine.Models;


BenchmarkRunner.Run<CompileBenchmarks>();

public record TestModel
{
    public string StringProperty { get; set; }
    public int IntProperty { get; set; }
    public double DoubleProperty { get; set; }
    public Dictionary<string, string> StringStringDictionaryProperty { get; set; }
    public IEnumerable<int> IntEnumerableProperty { get; set; }
    public IEnumerable<string> StringEnumerableProperty { get; set; }
    public string[] StringArrayProperty { get; set; }
}

public class CompileBenchmarks
{
    private static readonly Rule Rule = new(nameof(TestModel.StringProperty), OperatorType.Equal, "whatever", "001");

    private static readonly RuleCompiler Compiler = new();

    [Benchmark]
    public void Compile() => Compiler.Compile<TestModel>(Rule);
}
```


Results:
```
| Method        | Mean     | Error     | StdDev   |
|---------------|---------:|----------:|---------:|
| Compile       | 7.571 us | 0.4412 us | 1.208 us |
| Compile (FCE) | 105.3 us | 7.35 us   | 20.48 us |
```